### PR TITLE
FIX. root, body css 수정

### DIFF
--- a/ON-FRONTEND/public/reset.css
+++ b/ON-FRONTEND/public/reset.css
@@ -107,7 +107,6 @@ section {
 }
 body {
   line-height: 1;
-  max-width: 400px;
 }
 ol,
 ul {

--- a/ON-FRONTEND/src/App.css
+++ b/ON-FRONTEND/src/App.css
@@ -1,44 +1,45 @@
 @import '../public/reset.css';
 
 #root {
-    max-width: 1280px;
-    margin: 0 auto;
-    padding: 2rem;
-    text-align: center;
+  width: 100%;
+  height: 100%;
+  margin: 0 auto;
+  padding: 0px;
+  text-align: center;
 }
 
 .logo {
-    height: 6em;
-    padding: 1.5em;
-    will-change: filter;
-    transition: filter 300ms;
+  height: 6em;
+  padding: 1.5em;
+  will-change: filter;
+  transition: filter 300ms;
 }
 .logo:hover {
-    filter: drop-shadow(0 0 2em #646cffaa);
+  filter: drop-shadow(0 0 2em #646cffaa);
 }
 .logo.react:hover {
-    filter: drop-shadow(0 0 2em #61dafbaa);
+  filter: drop-shadow(0 0 2em #61dafbaa);
 }
 
 @keyframes logo-spin {
-    from {
-        transform: rotate(0deg);
-    }
-    to {
-        transform: rotate(360deg);
-    }
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 @media (prefers-reduced-motion: no-preference) {
-    a:nth-of-type(2) .logo {
-        animation: logo-spin infinite 20s linear;
-    }
+  a:nth-of-type(2) .logo {
+    animation: logo-spin infinite 20s linear;
+  }
 }
 
 .card {
-    padding: 2em;
+  padding: 2em;
 }
 
 .read-the-docs {
-    color: #888;
+  color: #888;
 }

--- a/ON-FRONTEND/src/index.css
+++ b/ON-FRONTEND/src/index.css
@@ -1,80 +1,80 @@
 :root {
-   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-   line-height: 1.5;
-   font-weight: 400;
+  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
 
-   color-scheme: light dark;
-   color: rgba(255, 255, 255, 0.87);
-   background-color: #242424;
+  color-scheme: light dark;
+  color: rgba(255, 255, 255, 0.87);
+  background-color: #242424;
 
-   font-synthesis: none;
-   text-rendering: optimizeLegibility;
-   -webkit-font-smoothing: antialiased;
-   -moz-osx-font-smoothing: grayscale;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 @font-face {
-   font-family: "BalooBhai-Regular";
-   font-weight: 400;
-   src: url("./assets/fonts/BalooBhai-Regular.ttf") format("ttf");
+  font-family: 'BalooBhai-Regular';
+  font-weight: 400;
+  src: url('./assets/fonts/BalooBhai-Regular.ttf') format('ttf');
 }
 
 @font-face {
-   font-family: "Inter-Regular";
-   font-weight: 400;
-   src: url("./assets/fonts/Inter-Regular.ttf") format("ttf");
+  font-family: 'Inter-Regular';
+  font-weight: 400;
+  src: url('./assets/fonts/Inter-Regular.ttf') format('ttf');
 }
 
 a {
-   font-weight: 500;
-   color: #646cff;
-   text-decoration: inherit;
+  font-weight: 500;
+  color: #646cff;
+  text-decoration: inherit;
 }
 a:hover {
-   color: #535bf2;
+  color: #535bf2;
 }
 
 body {
-   margin: 0;
-   display: flex;
-   place-items: center;
-   min-width: 320px;
-   min-height: 100vh;
+  margin: 0px;
+  display: flex;
+  place-items: center;
+  min-width: 320px;
+  min-height: 100vh;
 }
 
 h1 {
-   font-size: 3.2em;
-   line-height: 1.1;
+  font-size: 3.2em;
+  line-height: 1.1;
 }
 
 button {
-   border-radius: 8px;
-   border: 1px solid transparent;
-   padding: 0.6em 1.2em;
-   font-size: 1em;
-   font-weight: 500;
-   font-family: inherit;
-   background-color: #1a1a1a;
-   cursor: pointer;
-   transition: border-color 0.25s;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  padding: 0.6em 1.2em;
+  font-size: 1em;
+  font-weight: 500;
+  font-family: inherit;
+  background-color: #1a1a1a;
+  cursor: pointer;
+  transition: border-color 0.25s;
 }
 button:hover {
-   border-color: #646cff;
+  border-color: #646cff;
 }
 button:focus,
 button:focus-visible {
-   outline: 4px auto -webkit-focus-ring-color;
+  outline: 4px auto -webkit-focus-ring-color;
 }
 
 @media (prefers-color-scheme: light) {
-   :root {
-      color: #213547;
-      background-color: #ffffff;
-   }
-   a:hover {
-      color: #747bff;
-   }
-   button {
-      background-color: #f9f9f9;
-   }
+  :root {
+    color: #213547;
+    background-color: #ffffff;
+  }
+  a:hover {
+    color: #747bff;
+  }
+  button {
+    background-color: #f9f9f9;
+  }
 }


### PR DESCRIPTION
루트랑 바디에 해당하는 reset.css와 index.css의 width와 margin 수정함.

예전에는 루트는 margin left 2em이 있어서 컴포넌트가 왼쪽에 붙어있지 않았는데, margin 0으로 바꿔서 문제 해결

또한 최대 width가 400으로 설정되어 있어서 화면이 큰 (iphone 14 pro max) 핸드폰은 전체화면 적용x. max-width없애서 해당 사항 fix

어디인지 모르겠지만 max-width 1280px는 필요 없는 코드여서 삭제